### PR TITLE
Several updates to the content of the blog

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -3,6 +3,7 @@ date: "{{ now.Format "2006-01-02" }}"
 title: "{{ replace .File.ContentBaseName "-" " " | title }}"
 tags: []
 twitter_card_image: ""
+draft: true
 ---
 
 {{< webcard "https://" >}}

--- a/content/posts/code-duddha.md
+++ b/content/posts/code-duddha.md
@@ -1,0 +1,9 @@
+---
+date: "2025-04-06"
+title: "コード・ブッダ"
+tags: ["小説","仏教"]
+twitter_card_image: "https://b-bunshun.ismcdn.jp/mwimgs/6/0/1500wm/img_60f25ed9534a5bf225e686c54da06cde121697.jpg"
+draft: true
+---
+
+{{< webcard "https://books.bunshun.jp/ud/book/num/9784163918945" >}}

--- a/content/posts/english-for-use-elf.md
+++ b/content/posts/english-for-use-elf.md
@@ -1,0 +1,9 @@
+---
+date: "2025-04-06"
+title: "使うための英語―ELF（世界の共通語）として学ぶ"
+tags: ["新書", "中公新書"]
+twitter_card_image: "https://www.chuko.co.jp/book/102836.jpg"
+draft: true
+---
+
+{{< webcard "https://www.chuko.co.jp/shinsho/2024/12/102836.html" >}}

--- a/content/posts/entrepreneurial-genius.md
+++ b/content/posts/entrepreneurial-genius.md
@@ -1,0 +1,9 @@
+---
+date: "2025-03-16"
+title: "起業の天才!"
+tags: ["新書", "新潮文庫", "伝記"]
+twitter_card_image: "https://www.shinchosha.co.jp/images_v2/book/cover/101262/101262_l.jpg"
+draft: true
+---
+
+{{< webcard "https://www.shinchosha.co.jp/book/101262/" >}}

--- a/content/posts/learn-religion-to-understand-management.md
+++ b/content/posts/learn-religion-to-understand-management.md
@@ -1,0 +1,11 @@
+---
+date: "2025-03-30"
+title: "宗教を学べば経営がわかる"
+tags: ["新書", "文春新書"]
+twitter_card_image: "https://b-bunshun.ismcdn.jp/mwimgs/a/d/1500wm/img_adbddb69cd9391771c4b16b6f5f1db7d359892.jpg"
+draft: true
+---
+
+{{< webcard "https://books.bunshun.jp/ud/book/num/9784166614622" >}}
+
+三宅香帆さんとTBSの竹下さんが、1ヶ月間で読んだ書籍を紹介し合う `Page Turners` というyoutubeの企画があり、そこで紹介されていて知った書籍の一つです。ちなみに、この `Page Turners` の書籍は、[Page Turnersブックリスト - Google Documents](https://www.youtube.com/redirect?event=video_description&redir_token=QUFFLUhqbklkaFVyc2RnTExSZlFldVoxbFlTM3luRFhqZ3xBQ3Jtc0tsZjVLN2pBaEhNelZXbEg1NXU3OVdOWEdZa2RxNkNHVXIzTzRMcS1NV0h5UnV2RWNoYkRQNzd0NXExblFURlRQem9yZ3ZBVGJaQlhEUUhwLWdzaWktX3BuY3J6RXQ2OVNiaGdsX09BRlNjVUt2NmQ3Yw&q=https%3A%2F%2Fdocs.google.com%2Fdocument%2Fd%2F1X83HyGtnX_1WBWzv9lK_wDdZUQNGfi8ab4465dRTopQ%2Fedit%3Ftab%3Dt.0%23heading%3Dh.nnyp2fsp5fzn&v=jNySTkVN6zY) で公開されているようです。

--- a/content/posts/the-sickness-of-refuting.md
+++ b/content/posts/the-sickness-of-refuting.md
@@ -1,0 +1,9 @@
+---
+date: "2025-03-30"
+title: "論破という病"
+tags: ["新書", "中公新書ラクレ"]
+twitter_card_image: "https://www.chuko.co.jp/book/150834.jpg"
+draft: true
+---
+
+{{< webcard "https://www.chuko.co.jp/laclef/2025/02/150834.html" >}}


### PR DESCRIPTION
This pull request includes several updates to the content of the blog, primarily adding new posts and setting drafts. The most important changes include adding metadata and content for new blog posts, and setting the draft status for these posts.

New blog posts added:

* [`content/posts/code-duddha.md`](diffhunk://#diff-00f6889cca46e248db8425d7698c2a38296d525f45ebad072099da8eb0108444R1-R9): Added metadata and content for the post titled "コード・ブッダ".
* [`content/posts/english-for-use-elf.md`](diffhunk://#diff-9fb27cea448e44e5a00cbfa874223bef90c4e2bf78c24f369fdf90185ee14e12R1-R9): Added metadata and content for the post titled "使うための英語―ELF（世界の共通語）として学ぶ".
* [`content/posts/entrepreneurial-genius.md`](diffhunk://#diff-b6bf66d9033aa6991c1c11747c6946ed4c289550b3cabac5fc1b22abe2dd5679R1-R9): Added metadata and content for the post titled "起業の天才!".
* [`content/posts/learn-religion-to-understand-management.md`](diffhunk://#diff-d689d21dcab89e889d33ec734ace5bcce097afa931e95c7ba78f1f5a0612f6f4R1-R11): Added metadata and content for the post titled "宗教を学べば経営がわかる".
* [`content/posts/the-sickness-of-refuting.md`](diffhunk://#diff-98a4e72c20006285c0fa5bbfa18043a7363be104e61804883c414a0e269f0fd3R1-R9): Added metadata and content for the post titled "論破という病".

Draft status set:

* [`archetypes/default.md`](diffhunk://#diff-66e33766e433c71e7b748e30bfdd034f65e9ec01b2c7ebb4a4e7d5a180caeb80R6): Set the draft status to true for new posts.
